### PR TITLE
Fixed override mouse keybind issues on first loading and during combat, added toggles for override mouse keybinds

### DIFF
--- a/CombatMode/CombatMode.lua
+++ b/CombatMode/CombatMode.lua
@@ -259,7 +259,7 @@ end
 
 -- Default button values
 function CombatMode:OnInitialize()
-	databaseDefaults = {
+		databaseDefaults = {
 		global = {
 		  version = "1.0.0",
 			watchlist = {
@@ -487,6 +487,8 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.button1.value = value
+									CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1.value,
+										self.db.profile.bindings.button1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.button1.value
@@ -501,6 +503,8 @@ function CombatMode:OnInitialize()
 								order = 2,
 								set = function(info, value)
 									self.db.profile.bindings.button1macro = value
+									CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1.value,
+										self.db.profile.bindings.button1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.button1macro
@@ -518,6 +522,8 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.button2.value = value
+									CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2.value,
+										self.db.profile.bindings.button2macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.button2.value
@@ -532,6 +538,8 @@ function CombatMode:OnInitialize()
 								order = 4,
 								set = function(info, value)
 									self.db.profile.bindings.button2macro = value
+									CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2.value,
+										self.db.profile.bindings.button2macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.button2macro
@@ -559,6 +567,8 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.shiftbutton1.value = value
+									CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1.value,
+										self.db.profile.bindings.shiftbutton1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.shiftbutton1.value
@@ -573,6 +583,8 @@ function CombatMode:OnInitialize()
 								order = 2,
 								set = function(info, value)
 									self.db.profile.bindings.shiftbutton1macro = value
+									CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1.value,
+										self.db.profile.bindings.shiftbutton1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.shiftbutton1macro
@@ -590,6 +602,8 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.shiftbutton2.value = value
+									CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton1.value,
+										self.db.profile.bindings.shiftbutton1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.shiftbutton2.value
@@ -604,6 +618,8 @@ function CombatMode:OnInitialize()
 								order = 4,
 								set = function(info, value)
 									self.db.profile.bindings.shiftbutton2macro = value
+									CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton1.value,
+										self.db.profile.bindings.shiftbutton1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.shiftbutton2macro
@@ -631,6 +647,8 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.ctrlbutton1.value = value
+									CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1.value,
+										self.db.profile.bindings.ctrlbutton1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.ctrlbutton1.value
@@ -645,6 +663,8 @@ function CombatMode:OnInitialize()
 								order = 2,
 								set = function(info, value)
 									self.db.profile.bindings.ctrlbutton1macro = value
+									CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1.value,
+										self.db.profile.bindings.ctrlbutton1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.ctrlbutton1macro
@@ -662,6 +682,8 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.ctrlbutton2.value = value
+									CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2.value,
+										self.db.profile.bindings.ctrlbutton2macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.ctrlbutton2.value
@@ -676,6 +698,8 @@ function CombatMode:OnInitialize()
 								order = 4,
 								set = function(info, value)
 									self.db.profile.bindings.ctrlbutton2macro = value
+									CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2.value,
+										self.db.profile.bindings.ctrlbutton2macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.ctrlbutton2macro
@@ -703,6 +727,8 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.altbutton1.value = value
+									CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1.value,
+										self.db.profile.bindings.altbutton1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.altbutton1.value
@@ -717,6 +743,8 @@ function CombatMode:OnInitialize()
 								order = 2,
 								set = function(info, value)
 									self.db.profile.bindings.altbutton1macro = value
+									CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1.value,
+										self.db.profile.bindings.altbutton1macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.altbutton1macro
@@ -734,6 +762,8 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.altbutton2.value = value
+									CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2.value,
+										self.db.profile.bindings.altbutton2macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.altbutton2.value
@@ -748,6 +778,8 @@ function CombatMode:OnInitialize()
 								order = 4,
 								set = function(info, value)
 									self.db.profile.bindings.altbutton2macro = value
+									CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2.value,
+										self.db.profile.bindings.altbutton2macro)
 								end,
 								get = function()
 									return self.db.profile.bindings.altbutton2macro
@@ -1092,6 +1124,8 @@ end
 
 
 function CombatMode:OnEnable()
+	CombatMode:BindBindingOverrides()
+
 	CombatMode:InitializeWildcardFrameTracking(wildcardFramesToMatch)
 
 	self:CreateCrosshair()
@@ -1118,8 +1152,6 @@ function CombatMode:OnDisable()
 end
 
 function CombatMode:BindBindingOverride(button, value, macroValue)
-	MouselookStop()
-
 	local valueToUse
 	if value == defaultButtonValues.MACRO then
 		valueToUse = "MACRO " .. macroValue
@@ -1128,7 +1160,7 @@ function CombatMode:BindBindingOverride(button, value, macroValue)
 	end
 	SetMouselookOverrideBinding(button, valueToUse)
 
-	MouselookStart()
+	CombatMode:print(button .. "'s override binding is now " .. value)
 end
 
 function CombatMode:BindBindingOverrides()
@@ -1229,7 +1261,6 @@ end
 function CombatMode:Toggle()
 	if combatModeAddonSwitch == false then
 		combatModeAddonSwitch = true
-		CombatMode:BindBindingOverrides()
 		CombatMode:startMouselook()
 	else
 		combatModeAddonSwitch = false

--- a/CombatMode/CombatMode.lua
+++ b/CombatMode/CombatMode.lua
@@ -278,50 +278,43 @@ function CombatMode:OnInitialize()
 				button1 = {
 					key = "BUTTON1",
 					value = "ACTIONBUTTON1",
+					macro = ""
 				},
-				button1macro = "",
-
 				button2 = {
 					key = "BUTTON2",
 					value = "ACTIONBUTTON2",
+					macro = ""
 				},
-				button2macro = "",
-
 				shiftbutton1 = {
 					key = "SHIFT-BUTTON1",
 					value = "ACTIONBUTTON3",
+					macro = ""
 				},
-				shiftbutton1macro = "",
-
 				shiftbutton2 = {
 					key = "SHIFT-BUTTON2",
 					value = "ACTIONBUTTON4",
+					macro = ""
 				},
-				shiftbutton2macro = "",
-
 				ctrlbutton1 = {
 					key = "CTRL-BUTTON1",
 					value = "ACTIONBUTTON5",
+					macro = ""
 				},
-				ctrlbutton1macro = "",
-
 				ctrlbutton2 = {
 					key = "CTRL-BUTTON2",
 					value = "ACTIONBUTTON6",
+					macro = ""
 				},
-				ctrlbutton2macro = "",
-
 				altbutton1 = {
 					key = "ALT-BUTTON1",
 					value = "ACTIONBUTTON7",
+					macro = ""
 				},
-				altbutton1macro = "",
-
 				altbutton2 = {
 					key = "ALT-BUTTON2",
 					value = "ACTIONBUTTON8",
+					macro = ""
 				},
-				altbutton2macro = "",
 
 				toggle = {
 					key = "Combat Mode Toggle",
@@ -487,8 +480,7 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.button1.value = value
-									CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1.value,
-										self.db.profile.bindings.button1macro)
+									CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1)
 								end,
 								get = function()
 									return self.db.profile.bindings.button1.value
@@ -502,12 +494,11 @@ function CombatMode:OnInitialize()
 								width = 1.5,
 								order = 2,
 								set = function(info, value)
-									self.db.profile.bindings.button1macro = value
-									CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1.value,
-										self.db.profile.bindings.button1macro)
+									self.db.profile.bindings.button1.macro = value
+									CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1)
 								end,
 								get = function()
-									return self.db.profile.bindings.button1macro
+									return self.db.profile.bindings.button1.macro
 								end,
 								disabled = function()
 									return self.db.profile.bindings.button1.value ~= defaultButtonValues.MACRO
@@ -522,8 +513,7 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.button2.value = value
-									CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2.value,
-										self.db.profile.bindings.button2macro)
+									CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2)
 								end,
 								get = function()
 									return self.db.profile.bindings.button2.value
@@ -537,12 +527,11 @@ function CombatMode:OnInitialize()
 								width = 1.5,
 								order = 4,
 								set = function(info, value)
-									self.db.profile.bindings.button2macro = value
-									CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2.value,
-										self.db.profile.bindings.button2macro)
+									self.db.profile.bindings.button2.macro = value
+									CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2)
 								end,
 								get = function()
-									return self.db.profile.bindings.button2macro
+									return self.db.profile.bindings.button2.macro
 								end,
 								disabled = function()
 									return self.db.profile.bindings.button2.value ~= defaultButtonValues.MACRO
@@ -567,8 +556,7 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.shiftbutton1.value = value
-									CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1.value,
-										self.db.profile.bindings.shiftbutton1macro)
+									CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1)
 								end,
 								get = function()
 									return self.db.profile.bindings.shiftbutton1.value
@@ -582,12 +570,11 @@ function CombatMode:OnInitialize()
 								width = 1.5,
 								order = 2,
 								set = function(info, value)
-									self.db.profile.bindings.shiftbutton1macro = value
-									CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1.value,
-										self.db.profile.bindings.shiftbutton1macro)
+									self.db.profile.bindings.shiftbutton1.macro = value
+									CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1)
 								end,
 								get = function()
-									return self.db.profile.bindings.shiftbutton1macro
+									return self.db.profile.bindings.shiftbutton1.macro
 								end,
 								disabled = function()
 									return self.db.profile.bindings.shiftbutton1.value ~= defaultButtonValues.MACRO
@@ -602,8 +589,7 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.shiftbutton2.value = value
-									CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton1.value,
-										self.db.profile.bindings.shiftbutton1macro)
+									CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton2)
 								end,
 								get = function()
 									return self.db.profile.bindings.shiftbutton2.value
@@ -617,12 +603,11 @@ function CombatMode:OnInitialize()
 								width = 1.5,
 								order = 4,
 								set = function(info, value)
-									self.db.profile.bindings.shiftbutton2macro = value
-									CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton1.value,
-										self.db.profile.bindings.shiftbutton1macro)
+									self.db.profile.bindings.shiftbutton2.macro = value
+									CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton2)
 								end,
 								get = function()
-									return self.db.profile.bindings.shiftbutton2macro
+									return self.db.profile.bindings.shiftbutton2.macro
 								end,
 								disabled = function()
 									return self.db.profile.bindings.shiftbutton2.value ~= defaultButtonValues.MACRO
@@ -647,8 +632,7 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.ctrlbutton1.value = value
-									CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1.value,
-										self.db.profile.bindings.ctrlbutton1macro)
+									CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1)
 								end,
 								get = function()
 									return self.db.profile.bindings.ctrlbutton1.value
@@ -662,12 +646,11 @@ function CombatMode:OnInitialize()
 								width = 1.5,
 								order = 2,
 								set = function(info, value)
-									self.db.profile.bindings.ctrlbutton1macro = value
-									CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1.value,
-										self.db.profile.bindings.ctrlbutton1macro)
+									self.db.profile.bindings.ctrlbutton1.macro = value
+									CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1)
 								end,
 								get = function()
-									return self.db.profile.bindings.ctrlbutton1macro
+									return self.db.profile.bindings.ctrlbutton1.macro
 								end,
 								disabled = function()
 									return self.db.profile.bindings.ctrlbutton1.value ~= defaultButtonValues.MACRO
@@ -682,8 +665,7 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.ctrlbutton2.value = value
-									CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2.value,
-										self.db.profile.bindings.ctrlbutton2macro)
+									CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2)
 								end,
 								get = function()
 									return self.db.profile.bindings.ctrlbutton2.value
@@ -697,12 +679,11 @@ function CombatMode:OnInitialize()
 								width = 1.5,
 								order = 4,
 								set = function(info, value)
-									self.db.profile.bindings.ctrlbutton2macro = value
-									CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2.value,
-										self.db.profile.bindings.ctrlbutton2macro)
+									self.db.profile.bindings.ctrlbutton2.macro = value
+									CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2)
 								end,
 								get = function()
-									return self.db.profile.bindings.ctrlbutton2macro
+									return self.db.profile.bindings.ctrlbutton2.macro
 								end,
 								disabled = function()
 									return self.db.profile.bindings.ctrlbutton2.value ~= defaultButtonValues.MACRO
@@ -727,8 +708,7 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.altbutton1.value = value
-									CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1.value,
-										self.db.profile.bindings.altbutton1macro)
+									CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1)
 								end,
 								get = function()
 									return self.db.profile.bindings.altbutton1.value
@@ -742,12 +722,11 @@ function CombatMode:OnInitialize()
 								width = 1.5,
 								order = 2,
 								set = function(info, value)
-									self.db.profile.bindings.altbutton1macro = value
-									CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1.value,
-										self.db.profile.bindings.altbutton1macro)
+									self.db.profile.bindings.altbutton1.macro = value
+									CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1)
 								end,
 								get = function()
-									return self.db.profile.bindings.altbutton1macro
+									return self.db.profile.bindings.altbutton1.macro
 								end,
 								disabled = function()
 									return self.db.profile.bindings.altbutton1.value ~= defaultButtonValues.MACRO
@@ -762,8 +741,7 @@ function CombatMode:OnInitialize()
 								values = defaultButtonValues,
 								set = function(info, value)
 									self.db.profile.bindings.altbutton2.value = value
-									CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2.value,
-										self.db.profile.bindings.altbutton2macro)
+									CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2)
 								end,
 								get = function()
 									return self.db.profile.bindings.altbutton2.value
@@ -777,12 +755,11 @@ function CombatMode:OnInitialize()
 								width = 1.5,
 								order = 4,
 								set = function(info, value)
-									self.db.profile.bindings.altbutton2macro = value
-									CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2.value,
-										self.db.profile.bindings.altbutton2macro)
+									self.db.profile.bindings.altbutton2.macro = value
+									CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2)
 								end,
 								get = function()
-									return self.db.profile.bindings.altbutton2macro
+									return self.db.profile.bindings.altbutton2.macro
 								end,
 								disabled = function()
 									return self.db.profile.bindings.altbutton2.value ~= defaultButtonValues.MACRO
@@ -1165,22 +1142,14 @@ end
 
 function CombatMode:BindBindingOverrides()
 	MouselookStop()
-	CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1.value,
-		self.db.profile.bindings.button1macro)
-	CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2.value,
-		self.db.profile.bindings.button2macro)
-	CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1.value,
-		self.db.profile.bindings.ctrlbutton1macro)
-	CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2.value,
-		self.db.profile.bindings.ctrlbutton2macro)
-	CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1.value,
-		self.db.profile.bindings.altbutton1macro)
-	CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2.value,
-		self.db.profile.bindings.altbutton2macro)
-	CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1.value,
-		self.db.profile.bindings.shiftbutton1macro)
-	CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton2.value,
-		self.db.profile.bindings.shiftbutton2macro)
+	CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1)
+	CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2)
+	CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1)
+	CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2)
+	CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1)
+	CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2)
+	CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1)
+	CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton2)
 	MouselookStart()
 end
 

--- a/CombatMode/CombatMode.lua
+++ b/CombatMode/CombatMode.lua
@@ -257,9 +257,148 @@ function CombatMode:loadDefaultCvars()
   -- print("Combat Mode: Reticle Target CVars RESET")
 end
 
+function CombatMode:GetButtonOverrideGroup(modifier, groupOrder)
+	local button1Settings, button2Settings, groupName, button1Name, button1MacroName, button2Name, button2MacroName
+	if modifier then
+		button1Settings = modifier .. "button1"
+		button2Settings = modifier .. "button2"
+
+		local capitalisedModifier = (modifier:gsub("^%l", string.upper))
+		groupName = capitalisedModifier .. "-modified Clicks"
+		button1Name = capitalisedModifier .. " + Left Click"
+		button1MacroName = capitalisedModifier .. " + Left Click Macro"
+		button2Name = capitalisedModifier .. " + Right Click"
+		button2MacroName = capitalisedModifier .. " + Right Click Macro"
+	else
+		button1Settings = "button1"
+		button2Settings = "button2"
+
+		groupName = "Base Clicks"
+		button1Name = "Left Click"
+		button1MacroName = "Left Click Macro"
+		button2Name = "Right Click"
+		button2MacroName = "Right Click Macro"
+	end
+
+	return {
+		type = "group",
+		name = "|cff97a2ff" .. groupName .. "|r",
+		inline = true,
+		order = groupOrder,
+		args = {
+			overrideButton1Toggle = {
+				type = "toggle",
+				name = "",
+				width = 0.2,
+				order = 1,
+				set = function(_, value)
+					self.db.profile.bindings[button1Settings].enabled = value
+					if value then
+						CombatMode:BindBindingOverride(self.db.profile.bindings[button1Settings])
+					else
+						CombatMode:ResetBindingOverride(self.db.profile.bindings[button1Settings])
+					end
+				end,
+				get = function()
+					return self.db.profile.bindings[button1Settings].enabled
+				end,
+			},
+			button1 = {
+				name = button1Name,
+				desc = button1Name,
+				type = "select",
+				width = 1.5,
+				order = 1.1,
+				values = defaultButtonValues,
+				set = function(_, value)
+					self.db.profile.bindings[button1Settings].value = value
+					CombatMode:BindBindingOverride(self.db.profile.bindings[button1Settings])
+				end,
+				get = function()
+					return self.db.profile.bindings[button1Settings].value
+				end,
+				disabled = function()
+					return not self.db.profile.bindings[button1Settings].enabled
+				end
+			},
+			button1SidePadding = { type = "description", name = " ", width = 0.2, order = 1.2, },
+			button1macro = {
+				name = button1MacroName,
+				desc = macroFieldDescription,
+				type = "input",
+				width = 1.5,
+				order = 1.3,
+				set = function(_, value)
+					self.db.profile.bindings[button1Settings].macro = value
+					CombatMode:BindBindingOverride(self.db.profile.bindings[button1Settings])
+				end,
+				get = function()
+					return self.db.profile.bindings[button1Settings].macro
+				end,
+				disabled = function()
+					return not self.db.profile.bindings[button1Settings].enabled or self.db.profile.bindings[button1Settings].value ~= defaultButtonValues.MACRO
+				end
+			},
+			overrideButton2Toggle = {
+				type = "toggle",
+				name = "",
+				width = 0.2,
+				order = 2,
+				set = function(_, value)
+					self.db.profile.bindings[button2Settings].enabled = value
+					if value then
+						CombatMode:BindBindingOverride(self.db.profile.bindings[button2Settings])
+					else
+						CombatMode:ResetBindingOverride(self.db.profile.bindings[button2Settings])
+					end
+				end,
+				get = function()
+					return self.db.profile.bindings[button2Settings].enabled
+				end,
+			},
+			button2 = {
+				name = button2Name,
+				desc = button2Name,
+				type = "select",
+				width = 1.5,
+				order = 2.1,
+				values = defaultButtonValues,
+				set = function(_, value)
+					self.db.profile.bindings[button2Settings].value = value
+					CombatMode:BindBindingOverride(self.db.profile.bindings[button2Settings])
+				end,
+				get = function()
+					return self.db.profile.bindings[button2Settings].value
+				end,
+				disabled = function()
+					return not self.db.profile.bindings[button2Settings].enabled
+				end
+			},
+			button2SidePadding = { type = "description", name = " ", width = 0.2, order = 2.2, },
+			button2macro = {
+				name = button2MacroName,
+				desc = macroFieldDescription,
+				type = "input",
+				width = 1.5,
+				order = 2.3,
+				set = function(_, value)
+					self.db.profile.bindings[button2Settings].macro = value
+					CombatMode:BindBindingOverride(self.db.profile.bindings[button2Settings])
+				end,
+				get = function()
+					return self.db.profile.bindings[button2Settings].macro
+				end,
+				disabled = function()
+					return not self.db.profile.bindings[button2Settings].enabled or self.db.profile.bindings[button2Settings].value ~= defaultButtonValues.MACRO
+				end
+			},
+		},
+	}
+end
+
 -- Default button values
 function CombatMode:OnInitialize()
-		databaseDefaults = {
+	databaseDefaults = {
 		global = {
 		  version = "1.0.0",
 			watchlist = {
@@ -276,41 +415,49 @@ function CombatMode:OnInitialize()
 		profile = {
 			bindings = {
 				button1 = {
+					enabled = true,
 					key = "BUTTON1",
 					value = "ACTIONBUTTON1",
 					macro = ""
 				},
 				button2 = {
+					enabled = true,
 					key = "BUTTON2",
 					value = "ACTIONBUTTON2",
 					macro = ""
 				},
 				shiftbutton1 = {
+					enabled = true,
 					key = "SHIFT-BUTTON1",
 					value = "ACTIONBUTTON3",
 					macro = ""
 				},
 				shiftbutton2 = {
+					enabled = true,
 					key = "SHIFT-BUTTON2",
 					value = "ACTIONBUTTON4",
 					macro = ""
 				},
 				ctrlbutton1 = {
+					enabled = true,
 					key = "CTRL-BUTTON1",
 					value = "ACTIONBUTTON5",
 					macro = ""
 				},
 				ctrlbutton2 = {
+					enabled = true,
 					key = "CTRL-BUTTON2",
 					value = "ACTIONBUTTON6",
 					macro = ""
 				},
 				altbutton1 = {
+					enabled = true,
 					key = "ALT-BUTTON1",
 					value = "ACTIONBUTTON7",
 					macro = ""
 				},
 				altbutton2 = {
+					enabled = true,
 					key = "ALT-BUTTON2",
 					value = "ACTIONBUTTON8",
 					macro = ""
@@ -464,309 +611,13 @@ function CombatMode:OnInitialize()
 						order = 3,
 					},
 					keybindDescriptionBottomPadding = {type = "description", name = " ", width = "full", order = 3.1, },
-					-- BASE CLICK GROUP
-					unmodifiedGroup = {
-						type = "group",
-						name = "|cff97a2ffBase Clicks|r",
-						inline = true,
-						order = 4,
-						args = {
-							button1 = {
-								name = "Left Click",
-								desc = "Left Click",
-								type = "select",
-								width = 1.5,
-								order = 1,
-								values = defaultButtonValues,
-								set = function(info, value)
-									self.db.profile.bindings.button1.value = value
-									CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1)
-								end,
-								get = function()
-									return self.db.profile.bindings.button1.value
-								end
-							},
-							button1SidePadding = { type = "description", name = " ", width = 0.2, order = 1.1, },
-							button1macro = {
-								name = "Left Click Macro",
-								desc = macroFieldDescription,
-								type = "input",
-								width = 1.5,
-								order = 2,
-								set = function(info, value)
-									self.db.profile.bindings.button1.macro = value
-									CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1)
-								end,
-								get = function()
-									return self.db.profile.bindings.button1.macro
-								end,
-								disabled = function()
-									return self.db.profile.bindings.button1.value ~= defaultButtonValues.MACRO
-								end
-							},
-							button2 = {
-								name = "Right Click",
-								desc = "Right Click",
-								type = "select",
-								width = 1.5,
-								order = 3,
-								values = defaultButtonValues,
-								set = function(info, value)
-									self.db.profile.bindings.button2.value = value
-									CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2)
-								end,
-								get = function()
-									return self.db.profile.bindings.button2.value
-								end
-							},
-							button2SidePadding = { type = "description", name = " ", width = 0.2, order = 3.1, },
-							button2macro = {
-								name = "Right Click Macro",
-								desc = macroFieldDescription,
-								type = "input",
-								width = 1.5,
-								order = 4,
-								set = function(info, value)
-									self.db.profile.bindings.button2.macro = value
-									CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2)
-								end,
-								get = function()
-									return self.db.profile.bindings.button2.macro
-								end,
-								disabled = function()
-									return self.db.profile.bindings.button2.value ~= defaultButtonValues.MACRO
-								end
-							},
-						},
-					},
+					unmodifiedGroup = CombatMode:GetButtonOverrideGroup(nil, 4),
 					unmodifiedGroupBottomPadding = { type = "description", name = " ", width = "full", order = 4.1, },
-					-- SHIFT CLICK GROUP
-					shiftGroup = {
-						type = "group",
-						name = "|cff97a2ffShift-modified Clicks|r",
-						inline = true,
-						order = 5,
-						args = {
-							shiftbutton1 = {
-								name = "Shift + Left Click",
-								desc = "Shift + Left Click",
-								type = "select",
-								width = 1.5,
-								order = 1,
-								values = defaultButtonValues,
-								set = function(info, value)
-									self.db.profile.bindings.shiftbutton1.value = value
-									CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1)
-								end,
-								get = function()
-									return self.db.profile.bindings.shiftbutton1.value
-								end
-							},
-							shiftbutton1SidePadding = { type = "description", name = " ", width = 0.2, order = 1.1, },
-							shiftbutton1macro = {
-								name = "Shift + Left Click Macro",
-								desc = macroFieldDescription,
-								type = "input",
-								width = 1.5,
-								order = 2,
-								set = function(info, value)
-									self.db.profile.bindings.shiftbutton1.macro = value
-									CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1)
-								end,
-								get = function()
-									return self.db.profile.bindings.shiftbutton1.macro
-								end,
-								disabled = function()
-									return self.db.profile.bindings.shiftbutton1.value ~= defaultButtonValues.MACRO
-								end
-							},
-							shiftbutton2 = {
-								name = "Shift + Right Click",
-								desc = "Shift + Right Click",
-								type = "select",
-								width = 1.5,
-								order = 3,
-								values = defaultButtonValues,
-								set = function(info, value)
-									self.db.profile.bindings.shiftbutton2.value = value
-									CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton2)
-								end,
-								get = function()
-									return self.db.profile.bindings.shiftbutton2.value
-								end
-							},
-							shiftbutton2SidePadding = { type = "description", name = " ", width = 0.2, order = 3.1, },
-							shiftbutton2macro = {
-								name = "Shift + Right Click Macro",
-								desc = macroFieldDescription,
-								type = "input",
-								width = 1.5,
-								order = 4,
-								set = function(info, value)
-									self.db.profile.bindings.shiftbutton2.macro = value
-									CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton2)
-								end,
-								get = function()
-									return self.db.profile.bindings.shiftbutton2.macro
-								end,
-								disabled = function()
-									return self.db.profile.bindings.shiftbutton2.value ~= defaultButtonValues.MACRO
-								end
-							},
-						},
-					},
+					shiftGroup = CombatMode:GetButtonOverrideGroup("shift", 5),
 					shiftGroupBottomPadding = { type = "description", name = " ", width = "full", order = 5.1, },
-					-- CTRL CLICK GROUP
-					ctrlGroup = {
-						type = "group",
-						name = "|cff97a2ffCTRL-modified Clicks|r",
-						inline = true,
-						order = 6,
-						args = {
-							ctrlbutton1 = {
-								name = "Control + Left Click",
-								desc = "Control + Left Click",
-								type = "select",
-								width = 1.5,
-								order = 1,
-								values = defaultButtonValues,
-								set = function(info, value)
-									self.db.profile.bindings.ctrlbutton1.value = value
-									CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1)
-								end,
-								get = function()
-									return self.db.profile.bindings.ctrlbutton1.value
-								end
-							},
-							ctrlbutton1SidePadding = { type = "description", name = " ", width = 0.2, order = 1.1, },
-							ctrlbutton1macro = {
-								name = "Control + Left Click Macro",
-								desc = macroFieldDescription,
-								type = "input",
-								width = 1.5,
-								order = 2,
-								set = function(info, value)
-									self.db.profile.bindings.ctrlbutton1.macro = value
-									CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1)
-								end,
-								get = function()
-									return self.db.profile.bindings.ctrlbutton1.macro
-								end,
-								disabled = function()
-									return self.db.profile.bindings.ctrlbutton1.value ~= defaultButtonValues.MACRO
-								end
-							},
-							ctrlbutton2 = {
-								name = "Control + Right Click",
-								desc = "Control + Right Click",
-								type = "select",
-								width = 1.5,
-								order = 3,
-								values = defaultButtonValues,
-								set = function(info, value)
-									self.db.profile.bindings.ctrlbutton2.value = value
-									CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2)
-								end,
-								get = function()
-									return self.db.profile.bindings.ctrlbutton2.value
-								end
-							},
-							ctrlbutton2SidePadding = { type = "description", name = " ", width = 0.2, order = 3.1, },
-							ctrlbutton2macro = {
-								name = "Control + Right Click Macro",
-								desc = macroFieldDescription,
-								type = "input",
-								width = 1.5,
-								order = 4,
-								set = function(info, value)
-									self.db.profile.bindings.ctrlbutton2.macro = value
-									CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2)
-								end,
-								get = function()
-									return self.db.profile.bindings.ctrlbutton2.macro
-								end,
-								disabled = function()
-									return self.db.profile.bindings.ctrlbutton2.value ~= defaultButtonValues.MACRO
-								end
-							},
-						},
-					},
+					ctrlGroup = CombatMode:GetButtonOverrideGroup("ctrl", 6),
 					ctrlGroupBottomPadding = { type = "description", name = " ", width = "full", order = 6.1, },
-					-- ALT CLICK GROUP
-					altGroup = {
-						type = "group",
-						name = "|cff97a2ffALT-modified Clicks|r",
-						inline = true,
-						order = 7,
-						args = {
-							altbutton1 = {
-								name = "Alt + Left Click",
-								desc = "Alt + Left Click",
-								type = "select",
-								width = 1.5,
-								order = 1,
-								values = defaultButtonValues,
-								set = function(info, value)
-									self.db.profile.bindings.altbutton1.value = value
-									CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1)
-								end,
-								get = function()
-									return self.db.profile.bindings.altbutton1.value
-								end
-							},
-							altbutton1SidePadding = { type = "description", name = " ", width = 0.2, order = 1.1, },
-							altbutton1macro = {
-								name = "Alt + Left Click Macro",
-								desc = macroFieldDescription,
-								type = "input",
-								width = 1.5,
-								order = 2,
-								set = function(info, value)
-									self.db.profile.bindings.altbutton1.macro = value
-									CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1)
-								end,
-								get = function()
-									return self.db.profile.bindings.altbutton1.macro
-								end,
-								disabled = function()
-									return self.db.profile.bindings.altbutton1.value ~= defaultButtonValues.MACRO
-								end
-							},
-							altbutton2 = {
-								name = "Alt + Right Click",
-								desc = "Alt + Right Click",
-								type = "select",
-								width = 1.5,
-								order = 3,
-								values = defaultButtonValues,
-								set = function(info, value)
-									self.db.profile.bindings.altbutton2.value = value
-									CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2)
-								end,
-								get = function()
-									return self.db.profile.bindings.altbutton2.value
-								end
-							},
-							altbutton2SidePadding = { type = "description", name = " ", width = 0.2, order = 3.1, },
-							altbutton2macro = {
-								name = "Alt + Right Click Macro",
-								desc = macroFieldDescription,
-								type = "input",
-								width = 1.5,
-								order = 4,
-								set = function(info, value)
-									self.db.profile.bindings.altbutton2.macro = value
-									CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2)
-								end,
-								get = function()
-									return self.db.profile.bindings.altbutton2.macro
-								end,
-								disabled = function()
-									return self.db.profile.bindings.altbutton2.value ~= defaultButtonValues.MACRO
-								end
-							},
-						},
-					},					
+					altGroup = CombatMode:GetButtonOverrideGroup("alt", 7),
 				},
 			},
 			-- WATCHLIST
@@ -1128,28 +979,32 @@ function CombatMode:OnDisable()
     -- Called when the addon is disabled
 end
 
-function CombatMode:BindBindingOverride(button, value, macroValue)
-	local valueToUse
-	if value == defaultButtonValues.MACRO then
-		valueToUse = "MACRO " .. macroValue
-	else
-		valueToUse = value
-	end
-	SetMouselookOverrideBinding(button, valueToUse)
+function CombatMode:ResetBindingOverride(buttonSettings)
+	SetMouselookOverrideBinding(buttonSettings.key, nil)
+	CombatMode:print(buttonSettings.key .. "'s override binding is now cleared")
+end
 
-	CombatMode:print(button .. "'s override binding is now " .. value)
+function CombatMode:BindBindingOverride(buttonSettings)
+	local valueToUse
+	if buttonSettings.value == defaultButtonValues.MACRO then
+		valueToUse = "MACRO " .. buttonSettings.macro
+	else
+		valueToUse = buttonSettings.value
+	end
+	SetMouselookOverrideBinding(buttonSettings.key, valueToUse)
+	CombatMode:print(buttonSettings.key .. "'s override binding is now " .. valueToUse)
 end
 
 function CombatMode:BindBindingOverrides()
 	MouselookStop()
-	CombatMode:BindBindingOverride("BUTTON1", self.db.profile.bindings.button1)
-	CombatMode:BindBindingOverride("BUTTON2", self.db.profile.bindings.button2)
-	CombatMode:BindBindingOverride("CTRL-BUTTON1", self.db.profile.bindings.ctrlbutton1)
-	CombatMode:BindBindingOverride("CTRL-BUTTON2", self.db.profile.bindings.ctrlbutton2)
-	CombatMode:BindBindingOverride("ALT-BUTTON1", self.db.profile.bindings.altbutton1)
-	CombatMode:BindBindingOverride("ALT-BUTTON2", self.db.profile.bindings.altbutton2)
-	CombatMode:BindBindingOverride("SHIFT-BUTTON1", self.db.profile.bindings.shiftbutton1)
-	CombatMode:BindBindingOverride("SHIFT-BUTTON2", self.db.profile.bindings.shiftbutton2)
+	CombatMode:BindBindingOverride(self.db.profile.bindings.button1)
+	CombatMode:BindBindingOverride(self.db.profile.bindings.button2)
+	CombatMode:BindBindingOverride(self.db.profile.bindings.shiftbutton1)
+	CombatMode:BindBindingOverride(self.db.profile.bindings.shiftbutton2)
+	CombatMode:BindBindingOverride(self.db.profile.bindings.ctrlbutton1)
+	CombatMode:BindBindingOverride(self.db.profile.bindings.ctrlbutton2)
+	CombatMode:BindBindingOverride(self.db.profile.bindings.altbutton1)
+	CombatMode:BindBindingOverride(self.db.profile.bindings.altbutton2)
 	MouselookStart()
 end
 


### PR DESCRIPTION
Tested on retail, wrath classic, and classic era