### PR TITLE
fix: healing radial now respects user's mouse button binding settings

### DIFF
--- a/CombatMode/Config.lua
+++ b/CombatMode/Config.lua
@@ -150,6 +150,9 @@ local function GetButtonOverrideGroup(modifier, groupOrder)
           else
             CM.ResetBindingOverride(CM.DB[CM.GetBindingsLocation()].bindings[button1Settings])
           end
+          if CM.HealingRadial and CM.HealingRadial.OnBindingChanged then
+            CM.HealingRadial.OnBindingChanged()
+          end
         end,
         get = function()
           return CM.DB[CM.GetBindingsLocation()].bindings[button1Settings].enabled
@@ -166,6 +169,9 @@ local function GetButtonOverrideGroup(modifier, groupOrder)
         set = function(_, value)
           CM.DB[CM.GetBindingsLocation()].bindings[button1Settings].value = value
           CM.SetNewBinding(CM.DB[CM.GetBindingsLocation()].bindings[button1Settings])
+          if CM.HealingRadial and CM.HealingRadial.OnBindingChanged then
+            CM.HealingRadial.OnBindingChanged()
+          end
         end,
         get = function()
           return CM.DB[CM.GetBindingsLocation()].bindings[button1Settings].value
@@ -220,6 +226,9 @@ local function GetButtonOverrideGroup(modifier, groupOrder)
           else
             CM.ResetBindingOverride(CM.DB[CM.GetBindingsLocation()].bindings[button2Settings])
           end
+          if CM.HealingRadial and CM.HealingRadial.OnBindingChanged then
+            CM.HealingRadial.OnBindingChanged()
+          end
         end,
         get = function()
           return CM.DB[CM.GetBindingsLocation()].bindings[button2Settings].enabled
@@ -236,6 +245,9 @@ local function GetButtonOverrideGroup(modifier, groupOrder)
         set = function(_, value)
           CM.DB[CM.GetBindingsLocation()].bindings[button2Settings].value = value
           CM.SetNewBinding(CM.DB[CM.GetBindingsLocation()].bindings[button2Settings])
+          if CM.HealingRadial and CM.HealingRadial.OnBindingChanged then
+            CM.HealingRadial.OnBindingChanged()
+          end
         end,
         get = function()
           return CM.DB[CM.GetBindingsLocation()].bindings[button2Settings].value


### PR DESCRIPTION
The radial previously hard-coded action bar slots 1-8 for each button+modifier combo. Now it reads the user's configured bindings dynamically, so changing Left Click to ACTIONBUTTON7 (for example) correctly casts from slot 7 on the radial. Non-ACTIONBUTTON bindings fall back to targeting the party member on the slice. Binding changes in the Config panel immediately refresh the radial without /reload.